### PR TITLE
close response body.

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,6 +117,9 @@ func (c *Client) send(endpoint string, key string, value string) error {
 	values.Add("api_key", c.key)
 	values.Add(key, value)
 
-	_, err := c.client.PostForm(endpoint, values)
+	resp, err := c.client.PostForm(endpoint, values)
+	if err == nil {
+		resp.Body.Close()
+	}
 	return err
 }


### PR DESCRIPTION
from the [net/http documentation](https://golang.org/pkg/net/http/#Client.Do):

> If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close. If the Body is not both read to EOF and closed, the Client's underlying RoundTripper (typically Transport) may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.