### PR TITLE
Update client.go to use Amplitude API v2

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 )
 
-const eventEndpoint = "https://api.amplitude.com/httpapi"
+const eventEndpoint = "https://api.amplitude.com/2/httpapi"
 const identifyEndpoint = "https://api.amplitude.com/identify"
 
 // Client manages the communication to the Amplitude API


### PR DESCRIPTION
Just updated the URL; there shouldn't be any breaking changes according to: https://developers.amplitude.com/docs/http-api-v2#http-api-v2-improvements, although there is better validation / error reporting & messages, etc.